### PR TITLE
Include SFMono as monospace font

### DIFF
--- a/src/base.scss
+++ b/src/base.scss
@@ -7,6 +7,7 @@ $base-color-light: #f3f3f4;
 
 :root {
   --font-family: "Lato-Regular", "Helvetica Neue", Helvetica, "Segoe UI", -apple-system, BlinkMacSystemFont, Tahoma, Arial, sans-serif;
+  --font-family-mono: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier, monospace;
   --message-max-width: 50rem;
   --avatar-border-radius: 3px;
   --sidebar-icon-width: 35px;

--- a/src/components/code.scss
+++ b/src/components/code.scss
@@ -13,3 +13,7 @@
   background: var(--code-block-bg-color);
   color: var(--code-block-color);
 }
+
+code {
+  font-family: var(--font-family-mono) !important;
+}


### PR DESCRIPTION
This is what Github uses for its code font family.